### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   release:
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write
 
     strategy:
       matrix:


### PR DESCRIPTION
Potential fix for [https://github.com/Robertpham912/html-/security/code-scanning/6](https://github.com/Robertpham912/html-/security/code-scanning/6)

In general, the fix is to explicitly declare a `permissions` block in the workflow or in the specific job so that the GITHUB_TOKEN is granted only the minimal required scopes. For a build-and-release workflow that checks out code, builds artifacts, and uploads them to a GitHub Release, the typical minimum is `contents: write` (to manage release assets) rather than full, implicit read-write across all scopes.

The single best fix here is to add a `permissions` block at the job level under `jobs.release` so it applies only to this job. Because `softprops/action-gh-release` needs to upload assets to a release, it requires write access on repository contents. We therefore set `contents: write` and do not enable any other scopes. Concretely, in `.github/workflows/build-app.yml`, under `jobs:\n  release:`, insert:

```yaml
    permissions:
      contents: write
```

indented to align with `runs-on:`. This preserves existing functionality (the release upload keeps working) while constraining the GITHUB_TOKEN to just what is necessary.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
