### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - name: Kiểm tra code


### PR DESCRIPTION
Potential fix for [https://github.com/Robertpham912/html-/security/code-scanning/5](https://github.com/Robertpham912/html-/security/code-scanning/5)

In general, the fix is to declare a `permissions` block in the workflow (either at the root level or for the specific job) to restrict the `GITHUB_TOKEN` to only what is required. For this workflow, the build steps only read the repository (via `actions/checkout` and `zip`), and the only write operation is creating a release via `softprops/action-gh-release`. GitHub’s permission model exposes this as `contents: write` (for creating releases and uploading assets). So we can safely limit the token to `contents: write` at the job level.

Concretely, in `.github/workflows/release.yml`, under `jobs: build:`, add a `permissions:` section before `runs-on`. Set `contents: write` so that the action can create the release and upload `project.zip` while avoiding broader permissions such as `actions`, `issues`, etc. No imports or additional definitions are needed since this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
